### PR TITLE
cookie のドメイン指定を外した

### DIFF
--- a/shikakun.rb
+++ b/shikakun.rb
@@ -11,12 +11,10 @@ db = {
 
 configure :development do
   DB = Sequel.connect("sqlite://users.db")
-  DOMAIN = "127.0.0.1"
 end
 
 configure :production do
   DB = Sequel.connect("mysql2://#{db[:user]}:#{db[:password]}@#{db[:host]}/#{db[:dbname]}")
-  DOMAIN = "www.shikakun.com"
 end
 
 class Users < Sequel::Model
@@ -30,7 +28,6 @@ end
 
 use Rack::Session::Cookie,
   :key => 'rack.session',
-  :domain => DOMAIN,
   :path => '/',
   :expire_after => 3600,
   :secret => ENV['SESSION_SECRET']


### PR DESCRIPTION
ドメイン指定はなくてもいいし、むしろあると、以下の点で問題が。
- development 環境では DOMAIN が 127.0.0.1 になってるけど、そのせいで localhost でアクセスすると、ちゃんと動かない。（最初これでしばらくはまった。）
- 宮下が Sqale とかで動かそうとすると、コードの中の www.shikakun.com を修正しないといけない

ドメイン指定がなくても動くし、なければ上のような問題は起こらないので外しました。

また、こういう話もあるしね。
http://d.hatena.ne.jp/ockeghem/20111013/p1
