### PR TITLE
gem をグルーピング

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,14 @@ gem 'omniauth'
 gem 'omniauth-twitter'
 gem 'haml'
 gem 'sequel'
-gem 'sqlite3'
 gem 'twitter'
 gem 'sinatra-flash', require: "sinatra/flash"
 gem 'shotgun'
-gem 'mysql2'
+
+group :development do
+  gem 'sqlite3'
+end
+
+group :production do
+  gem 'mysql2'
+end


### PR DESCRIPTION
こうやってグループ分けしておくと、development 環境で mysql2 が必要ないので入れたくない場合に、

```
$ bundle install --deployment --without production
```

で入れないようにできて便利。
